### PR TITLE
Emit a diagnostic warning about parsing ambiguity in a conjunction

### DIFF
--- a/clang/include/clang/Basic/DiagnosticParseKinds.td
+++ b/clang/include/clang/Basic/DiagnosticParseKinds.td
@@ -1713,6 +1713,10 @@ let CategoryName = "Reflection Issue" in {
 def err_cannot_reflect_entity : Error<"cannot reflect entity">;
 def err_expansion_statements_disabled : Error<
   "'template for' statements are not enabled; use '-fexpansion-statements'">;
+
+def warn_parsing_ambiguity_in_refl_expression_with_ampamp_token : Warning <
+    "the compound condition may be misinterpreted due to '%0 &&' type parsing logic. did you mean '... (^%0) && ...'?"
+    >;
 }
 
 let CategoryName = "Generics Issue" in {

--- a/clang/lib/Parse/ParseDecl.cpp
+++ b/clang/lib/Parse/ParseDecl.cpp
@@ -6751,18 +6751,17 @@ void Parser::ParseDeclaratorInternal(Declarator &D,
     DeclSpec DS(AttrFactory);
 
     // Complain about:
-    // - rvalue references in C++03,
-    // - `^T &&` parsing ambiguity in C++2x
+    // - rvalue references in C++03
+    // - `^T &&` parsing ambiguity of compound expression with reflection in C++2x
     // but then go on and build the declarator.
     if (Kind == tok::ampamp) {
       if (D.getContext() == DeclaratorContext::ReflectOperator) {
-        std::string typeName = "T";
-        if (D.hasName()) {
-          typeName = Actions.GetNameForDeclarator(D).getName().getAsString();
-        }
+        // parser already consumed '^' token before setting this context
         Diag(Loc,
              diag::warn_parsing_ambiguity_in_refl_expression_with_ampamp_token)
-            << typeName;
+            << (D.hasName()
+                    ? Actions.GetNameForDeclarator(D).getName().getAsString()
+                    : "T");
       }
 
       Diag(Loc, getLangOpts().CPlusPlus11

--- a/clang/test/Parser/cxx2x-ambig-reflect-expr.cpp
+++ b/clang/test/Parser/cxx2x-ambig-reflect-expr.cpp
@@ -1,0 +1,32 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright 2024 Bloomberg Finance L.P.
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// RUN: %clang_cc1 -std=c++26 -freflection -verify %s
+
+
+enum MyEnum { x, y, e = -1, f, z = 99 };
+
+void func(MyEnum && x) { // ok
+  MyEnum value{};
+  MyEnum& ref = value;
+
+  constexpr auto reflValue = ^value;
+
+  constexpr bool test_comparison_0 = reflValue != (^MyEnum) && true; // ok
+  constexpr bool test_comparison_1 = (reflValue != (^MyEnum) && true); // ok
+
+  constexpr bool test_comparison_2 = ^MyEnum != (^MyEnum) && true; // ok
+  constexpr bool test_comparison_3 = (^MyEnum != (^MyEnum) && true); // ok
+
+  constexpr bool test_comparison_4 = reflValue != ^MyEnum && true;
+  // expected-warning@28 {{the compound condition may be misinterpreted due to 'T &&' type parsing logic. did you mean '... (^T) && ...'?}}
+  // expected-error@28 {{expected ';' at end of declaration}}
+}
+


### PR DESCRIPTION

## How did I test it?

- Added a basic parser test to catch a warning message, tested locally.
```shell
> env LIT_FILTER=cxx2x-ambig-reflect-expr.cpp ninja check-clang -C build-llvm/

ninja: Entering directory `build-llvm/'
[89/90] Running the Clang regression tests
llvm-lit: /home/balik/Desktop/clang-p2996/llvm/utils/lit/lit/llvm/config.py:509: note: using clang: /home/balik/Desktop/clang-p2996/build-llvm/bin/clang

Testing Time: 0.04s

Total Discovered Tests: 19357
  Excluded: 19356 (99.99%)
  Passed  :     1 (0.01%)

```

- Manually tested by compiling a code with mentioned issue

```cpp
#include <experimental/meta>
#include <iostream>

enum MyEnum { x, y, e = -1, f, z = 99 };

int main() {
  MyEnum value{};
  constexpr auto reflValue = ^value; 
  
  if (reflValue != ^MyEnum && true) {
    std::cout << "YES" << std::endl;
  } else {
    std::cout << "NO" << std::endl;
  }
}

```

```shell
> build-llvm/bin/clang++ -std=c++26 -freflection -Wl,-rpath,/home/balik/Development/clang-p2996/build-llvm/lib/x86_64-unknown-linux-gnu -L/home/balik/Development/clang-p2996/build-llvm/lib/x86_64-unknown-linux-gnu -stdlib=libc++ -lc++ -lc++abi -o a.out main.cpp

main.cpp:10:28: warning: the compound condition may be misinterpreted due to 'T &&' type parsing logic. did you mean '... (^T) && ...'?
   10 |   if (reflValue != ^MyEnum && true) {
      |                            ^
main.cpp:10:31: error: expected ')'
   10 |   if (reflValue != ^MyEnum && true) {
      |                               ^
main.cpp:10:6: note: to match this '('
   10 |   if (reflValue != ^MyEnum && true) {
      |      ^
1 warning and 1 error generated.

```

